### PR TITLE
feat(otimização): Implementa remoção de código morto

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -94,7 +94,7 @@ int main(int argc, char *argv[]) {
         printf("✅ Análise semântica concluída!\n\n");
         
         // FASE 3C: OTIMIZAÇÃO
-        printf("🚀 FASE 3C: Otimização (Propagação de Constantes)\n");
+        printf("🚀 FASE 3C: Otimização (Constantes, Simplificação e Código Morto)\n");
         printf("--------------------------------------\n");
         
         // Inicializar tabela de constantes
@@ -111,12 +111,17 @@ int main(int argc, char *argv[]) {
         // Passe 3: Simplificação de expressões
         printf("Passe 3: Simplificação de expressões...\n");
         ast_raiz = passeSimplificacaoExpressoes(ast_raiz);
+
+        // Passe 4: Remoção de código morto
+        printf("Passe 4: Remoção de código morto...\n");
+        ast_raiz = passeRemocaoCodigoMorto(ast_raiz);
         
-        // Passe 4: Repetir para fixpoint (propagação em cadeia)
-        printf("Passe 4: Fixpoint (segunda iteração)...\n");
+        // Passe 5: Repetir para fixpoint (propagação em cadeia)
+        printf("Passe 5: Fixpoint (segunda iteração)...\n");
         ast_raiz = passePropagacaoConstantes(ast_raiz);
         ast_raiz = passeConstantFolding(ast_raiz);
         ast_raiz = passeSimplificacaoExpressoes(ast_raiz);
+        ast_raiz = passeRemocaoCodigoMorto(ast_raiz);
         
         // Exibir estatísticas
         printf("\n");

--- a/src/otimizador/otimizador.h
+++ b/src/otimizador/otimizador.h
@@ -5,7 +5,7 @@
 
 // MÓDULO DE OTIMIZAÇÃO - PROPAGAÇÃO DE CONSTANTES
 
-//Estrutura que rmazenar valores constantes conhecidos
+// Estrutura que armazena valores constantes conhecidos
 typedef struct InfoConstante {
     char nome[32];
     int eh_constante;     
@@ -18,22 +18,22 @@ typedef struct InfoConstante {
     struct InfoConstante *proximo; 
 } InfoConstante;
 
-//Tabela de constantes
+// Tabela de constantes
 #define TAM_CONST 211
 
 // Inicializa a tabela de constantes (limpa todos os buckets)
-
 void inicializarTabelaConstantes(void);
 
+// Libera memória e limpa a tabela de constantes
 void limparTabelaConstantes(void);
 
-//Registra uma variável como constante com seu valor
-
+// Registra uma variável como constante com seu valor
 void registrarConstante(const char *nome, Tipo tipo, int valor_int, float valor_float);
 
-
+// Busca informação de constante pelo nome (ou NULL se não encontrada)
 InfoConstante* buscarConstante(const char *nome);
 
+// Invalida uma constante (deixa de ser considerada constante)
 void invalidarConstante(const char *nome);
 
 /**
@@ -59,13 +59,31 @@ Ast* passeConstantFolding(Ast *ast);
 
 /**
  * Passo de simplificação de expressões
- * - Simplifica expressões algébricas básicas
+ * - Simplifica expressões algébricas e lógicas básicas
+ *   Ex.: x + 0 → x, x * 1 → x, x - x → 0, x / 1 → x,
+ *        x == x → 1, x != x → 0, x && 0 → 0, x || 1 → 1,
+ *        !(!x) → x, -(-x) → x, etc.
  * 
  * @param ast Nó da AST a otimizar
  * @return AST otimizada (pode ser o mesmo nó ou novo nó)
  */
 Ast* passeSimplificacaoExpressoes(Ast *ast);
 
+/**
+ * Passo de remoção de código morto na AST
+ * - Remove:
+ *    * if (0) { ... }           → nada (ou else, se existir)
+ *    * if (1) { then } else { } → apenas then
+ *    * while (0) { ... }        → nada
+ *    * expressão solta sem efeito colateral (ex.: 1 + 2;)
+ * - Propaga remoção em listas de statements, blocos e funções.
+ * 
+ * @param ast Nó da AST a otimizar (programa, função, bloco, etc.)
+ * @return AST otimizada (pode ser o mesmo nó ou NULL, se eliminado)
+ */
+Ast* passeRemocaoCodigoMorto(Ast *ast);
+
+// Imprime estatísticas das otimizações realizadas
 void imprimirEstatisticasOtimizacao(void);
 
-#endif 
+#endif


### PR DESCRIPTION
# Implementação de Remoção de Código Morto

## Descrição

Implementa a funcionalidade de **remoção de código morto** no módulo de otimização do compilador C→Python, reduzindo o tamanho do código e o tempo de execução.

## Mudanças

### Arquivos Modificados
- **`src/otimizador/otimizador.c`**  
  - Implementa `passeRemocaoCodigoMorto()` para eliminar código morto na AST  
  - Adiciona helpers internos: `expressaoTemEfeitoColateral()`, `removerCodigoMortoLista()`  
  - Adiciona contador `stats_codigo_morto`
- **`src/otimizador/otimizador.h`**  
  - Adiciona declaração de `passeRemocaoCodigoMorto()`  
- **`src/main.c`**  
  - Integra a remoção de código morto ao pipeline de otimização (após simplificação de expressões e também na segunda passada de fixpoint)

---

## Remoção de Código Morto Implementada

A otimização atua na AST e remove construções que não afetam o comportamento observável do programa.

### Casos tratados

- **`if` com condição constante**
  - `if (0) { ... }` sem `else` → removido
  - `if (0) { ... } else { B }` → vira apenas `B`
  - `if (1) { A } else { B }` → vira apenas `A`

- **`while` com condição constante**
  - `while (0) { ... }` → removido (laço morto)

- **Expressões soltas sem efeito colateral**
  - Exemplos removidos: `1 + 2;`, `x * 3 - 2;`
  - Mantidas: chamadas de função, atribuições e qualquer nó com efeito colateral

- **Limpeza de listas de statements (`AST_LISTA`)**
  - Nós cujo `item` foi eliminado são removidos da lista, mantendo blocos consistentes

---

## Exemplo

**Antes:**

```c
int x = 10;

1 + 2;          // expressão solta
x * 3;          // expressão solta

if (0) {
    x = x + 1;
}

if (1) {
    x = x + 2;
} else {
    x = x + 3;
}

while (0) {
    x = x + 4;
}
```

**Depois:**

```c
int x = 10;

x = x + 2;      // if (1) → mantém apenas o bloco then
```

Closes #26 